### PR TITLE
Fix incorrect infowindow marker key name

### DIFF
--- a/Project_Code_3_WindowShoppingPart1.html
+++ b/Project_Code_3_WindowShoppingPart1.html
@@ -80,7 +80,7 @@
           infowindow.open(map, marker);
           // Make sure the marker property is cleared if the infowindow is closed.
           infowindow.addListener('closeclick',function(){
-            infowindow.setMarker = null;
+            infowindow.marker = null;
           });
         }
       }


### PR DESCRIPTION
Previously, closing an infowindow wouldn't correctly clear the marker property due to a naming issue which made it so that the same infowindow could not be opened again immediately after being closed without clicking on a different marker first to reset the property.

EDIT: A previous pull request addresses this issue.